### PR TITLE
Fix missing support-v4 bindings

### DIFF
--- a/UrbanAirship.nuspec
+++ b/UrbanAirship.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship</id>
-      <version>2.2.1</version>
+      <version>2.2.2</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -10,9 +10,9 @@
 
       <dependencies>
          <group targetFramework="MonoAndroid">
-            <dependency id="Xamarin.Android.Support.v4" version="23.3.0" />
-            <dependency id="Xamarin.Android.Support.v7.CardView" version="23.3.0" />
-            <dependency id="Xamarin.GooglePlayServices.Gcm" version="29.0.0.1" />
+            <dependency id="Xamarin.Android.Support.v4" version="23.4.0.1" />
+            <dependency id="Xamarin.Android.Support.v7.CardView" version="23.4.0.1" />
+            <dependency id="Xamarin.GooglePlayServices.Gcm" version="29.0.0.2" />
          </group>
       </dependencies>
    </metadata>

--- a/component/Details.md
+++ b/component/Details.md
@@ -4,11 +4,15 @@ This component provides official bindings to the Urban Airship SDK, as well as s
 
 ### Release Notes
 
+=============================
+Version 2.2.2 - July 22, 2016
+=============================
+- Fixed missing Android bindings for UrbanAirship.Push.Notifications package.
+
 ============================
 Version 2.2.1 - July 6, 2016
 ============================
-- Fixed native linking errors for missing
-  UAWalletAction on iOS
+- Fixed native linking errors for missing UAWalletAction on iOS
  
 ==========================
 Version 2.2 - June 2, 2016

--- a/component/component.yaml
+++ b/component/component.yaml
@@ -14,15 +14,15 @@ libraries:
 summary: A full suite of mobile engagement tools for building next-generation apps
 details: Details.md
 getting-started: GettingStarted.md
-version: "2.2.1"
+version: "2.2.2"
 samples:
   iOS Sample: ../samples/ios-unified/iOSSample.sln
   Android Sample: ../samples/android/AndroidSample.sln
 packages:
   android:
-    - urbanairship, Version=2.2.1
+    - urbanairship, Version=2.2.2
   ios-unified:
-    - urbanairship, Version=2.2.1
+    - urbanairship, Version=2.2.2
 is_shell: true
 no_build: true
 output: ../build

--- a/samples/android/Sample.csproj
+++ b/samples/android/Sample.csproj
@@ -16,7 +16,7 @@
     <AssemblyName>Sample</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
-    <ReleaseVersion>2.2.1</ReleaseVersion>
+    <ReleaseVersion>2.2.2</ReleaseVersion>
     <Description>Urban Airship Xamarin sample app for Android</Description>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>

--- a/samples/ios-unified/Sample.csproj
+++ b/samples/ios-unified/Sample.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Sample</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <ReleaseVersion>2.2.1</ReleaseVersion>
+    <ReleaseVersion>2.2.2</ReleaseVersion>
     <Description>Urban Airship Xamarin sample app for iOS</Description>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/AirshipBindings.Android/AirshipBindings.Android.csproj
+++ b/src/AirshipBindings.Android/AirshipBindings.Android.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{10368E6C-D01B-4462-8E8B-01FC667A7035};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{10368E6C-D01B-4462-8E8B-01FC667A7035};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{1CAD9B42-85C2-495A-AA2D-1EA2FCFE1C3B}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>UrbanAirship</RootNamespace>
@@ -12,7 +12,7 @@
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AssemblyName>AirshipBindings</AssemblyName>
     <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
-    <ReleaseVersion>2.2.1</ReleaseVersion>
+    <ReleaseVersion>2.2.2</ReleaseVersion>
     <Description>Urban Airship Xamarin bindings for Android</Description>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -42,23 +42,29 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
-    <Reference Include="Xamarin.Android.Support.v4">
-      <HintPath>..\..\samples\android\packages\Xamarin.Android.Support.v4.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Android.Support.v7.CardView">
-      <HintPath>..\..\samples\android\packages\Xamarin.Android.Support.v7.CardView.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.CardView.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Basement">
-      <HintPath>..\..\samples\android\packages\Xamarin.GooglePlayServices.Basement.29.0.0.1\lib\MonoAndroid41\Xamarin.GooglePlayServices.Basement.dll</HintPath>
+      <HintPath>packages\Xamarin.GooglePlayServices.Basement.29.0.0.2\lib\MonoAndroid41\Xamarin.GooglePlayServices.Basement.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Base">
-      <HintPath>..\..\samples\android\packages\Xamarin.GooglePlayServices.Base.29.0.0.1\lib\MonoAndroid41\Xamarin.GooglePlayServices.Base.dll</HintPath>
+      <HintPath>packages\Xamarin.GooglePlayServices.Base.29.0.0.2\lib\MonoAndroid41\Xamarin.GooglePlayServices.Base.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Measurement">
-      <HintPath>..\..\samples\android\packages\Xamarin.GooglePlayServices.Measurement.29.0.0.1\lib\MonoAndroid41\Xamarin.GooglePlayServices.Measurement.dll</HintPath>
+      <HintPath>packages\Xamarin.GooglePlayServices.Measurement.29.0.0.2\lib\MonoAndroid41\Xamarin.GooglePlayServices.Measurement.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Gcm">
-      <HintPath>..\..\samples\android\packages\Xamarin.GooglePlayServices.Gcm.29.0.0.1\lib\MonoAndroid41\Xamarin.GooglePlayServices.Gcm.dll</HintPath>
+      <HintPath>packages\Xamarin.GooglePlayServices.Gcm.29.0.0.2\lib\MonoAndroid41\Xamarin.GooglePlayServices.Gcm.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.CardView">
+      <HintPath>packages\Xamarin.Android.Support.v7.CardView.23.4.0.1\lib\MonoAndroid403\Xamarin.Android.Support.v7.CardView.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v4">
+      <HintPath>packages\Xamarin.Android.Support.v4.23.4.0.1\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -99,6 +105,7 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.Bindings.targets" />
+  <Import Project="packages\Xamarin.GooglePlayServices.Basement.29.0.0.2\build\Xamarin.GooglePlayServices.Basement.targets" Condition="Exists('packages\Xamarin.GooglePlayServices.Basement.29.0.0.2\build\Xamarin.GooglePlayServices.Basement.targets')" />
   <ItemGroup>
     <LibraryProjectZip Include="Jars\urbanairship-sdk-7.1.5-no-manifest.aar" />
   </ItemGroup>

--- a/src/AirshipBindings.Android/AirshipBindings.Android.sln
+++ b/src/AirshipBindings.Android/AirshipBindings.Android.sln
@@ -15,6 +15,6 @@ Global
 		{1CAD9B42-85C2-495A-AA2D-1EA2FCFE1C3B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 1.0
+		version = 2.2.2
 	EndGlobalSection
 EndGlobal

--- a/src/AirshipBindings.Android/Properties/AssemblyInfo.cs
+++ b/src/AirshipBindings.Android/Properties/AssemblyInfo.cs
@@ -18,7 +18,7 @@ using Android.App;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("2.2.1")]
+[assembly: AssemblyVersion ("2.2.2")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/src/AirshipBindings.Android/packages.config
+++ b/src/AirshipBindings.Android/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Android.Support.v4" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.Android.Support.v7.CardView" version="23.3.0" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.GooglePlayServices.Base" version="29.0.0.1" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.GooglePlayServices.Basement" version="29.0.0.1" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.GooglePlayServices.Gcm" version="29.0.0.1" targetFramework="MonoAndroid60" />
-  <package id="Xamarin.GooglePlayServices.Measurement" version="29.0.0.1" targetFramework="MonoAndroid60" />
+  <package id="Xamarin.Android.Support.v4" version="23.4.0.1" targetFramework="MonoAndroid60" />
+  <package id="Xamarin.Android.Support.v7.CardView" version="23.4.0.1" targetFramework="MonoAndroid60" />
+  <package id="Xamarin.GooglePlayServices.Base" version="29.0.0.2" targetFramework="MonoAndroid60" />
+  <package id="Xamarin.GooglePlayServices.Basement" version="29.0.0.2" targetFramework="MonoAndroid60" />
+  <package id="Xamarin.GooglePlayServices.Gcm" version="29.0.0.2" targetFramework="MonoAndroid60" />
+  <package id="Xamarin.GooglePlayServices.Measurement" version="29.0.0.2" targetFramework="MonoAndroid60" />
 </packages>

--- a/src/AirshipBindings.iOS/AirshipBindings.iOS.csproj
+++ b/src/AirshipBindings.iOS/AirshipBindings.iOS.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>AirshipBindings</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>AirshipBindings</AssemblyName>
-    <ReleaseVersion>2.2.1</ReleaseVersion>
+    <ReleaseVersion>2.2.2</ReleaseVersion>
     <Description>Urban Airship Xamarin bindings for iOS</Description>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/AirshipBindings.iOS/Properties/AssemblyInfo.cs
+++ b/src/AirshipBindings.iOS/Properties/AssemblyInfo.cs
@@ -25,7 +25,7 @@ using Foundation;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("2.2.1")]
+[assembly: AssemblyVersion ("2.2.2")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.


### PR DESCRIPTION
I believe this fixes missing bindings for most of the packages in UrbanAirship.Push.Notifications. 