### PR TITLE
Remove unused/undefined extern constant

### DIFF
--- a/src/AirshipBindings.iOS/ApiDefinition.cs
+++ b/src/AirshipBindings.iOS/ApiDefinition.cs
@@ -150,9 +150,6 @@ namespace UrbanAirship {
 		[Field("UALocationEventVerticalAccuracyKey", "__Internal")]
 		NSString UALocationEventVerticalAccuracyKey { get; }
 
-		// extern UALocationEventAnalyticsKey *const _Nonnull UALocationEventSessionIDKey;
-		[Field("UALocationEventSessionIDKey", "__Internal")]
-		NSString UALocationEventSessionIDKey { get; }
 
 		// extern UALocationEventUpdateType *const _Nonnull UALocationEventAnalyticsType;
 		[Field("UALocationEventAnalyticsType", "__Internal")]


### PR DESCRIPTION
Fixes #31 

The constant is listed here - https://github.com/urbanairship/ios-library/blob/master/Airship/Common/UALocationEvent.h#L47 but is never actually defined nor used in the SDK.