### PR TITLE
Fix iOS notification service extension

### DIFF
--- a/AirshipAppExtensions.nuspec
+++ b/AirshipAppExtensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship-app-extensions</id>
-      <version>3.0.0</version>
+      <version>3.1.0</version>
       <title>Urban Airship App Extensions</title>
       <authors>Urban Airship, Inc.</authors>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/UrbanAirship.nuspec
+++ b/UrbanAirship.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship</id>
-      <version>3.0.0</version>
+      <version>3.1.0</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/component/Details.md
+++ b/component/Details.md
@@ -3,10 +3,15 @@
 This component provides official bindings to the Urban Airship SDK, as well as sample applications for both iOS and Android.
 
 ### Release Notes
+================================
+Version 3.1.0 - October 12, 2016
+================================
+- Added iOS Urban Airship app extensions bindings
+- Fixed build errors when linker is disabled
 
-=============================
-Version 3.0 - October 4, 2016
-=============================
+===============================
+Version 3.0.0 - October 4, 2016
+===============================
 - Updated iOS Urban Airship SDK to 8.0.2
 
 =============================

--- a/component/component.yaml
+++ b/component/component.yaml
@@ -14,7 +14,7 @@ libraries:
 summary: A full suite of mobile engagement tools for building next-generation apps
 details: Details.md
 getting-started: GettingStarted.md
-version: "3.0.0"
+version: "3.1.0"
 samples:
   iOS Sample: ../samples/ios-unified/iOSSample.sln
   Android Sample: ../samples/android/AndroidSample.sln

--- a/src/AirshipBindings.iOS/AirshipBindings.iOS.csproj
+++ b/src/AirshipBindings.iOS/AirshipBindings.iOS.csproj
@@ -47,13 +47,23 @@
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+    <ObjcBindingApiDefinition Include="..\AirshipExtensionBindings.iOS\AirshipExtensionBindings.iOS\AirshipExtensionsApiDefinition.cs">
+      <Link>AirshipExtensionsApiDefinition.cs</Link>
+    </ObjcBindingApiDefinition>
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingCoreSource Include="StructsAndEnums.cs" />
+    <ObjcBindingCoreSource Include="..\AirshipExtensionBindings.iOS\AirshipExtensionBindings.iOS\AirshipExtensionsStructs.cs">
+      <Link>AirshipExtensionsStructs.cs</Link>
+    </ObjcBindingCoreSource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.ObjCBinding.CSharp.targets" />
   <ItemGroup>
     <NativeReference Include="..\..\Carthage\Build\iOS\AirshipKit.framework">
+      <Kind>Framework</Kind>
+      <SmartLink>False</SmartLink>
+    </NativeReference>
+    <NativeReference Include="..\..\Carthage\Build\iOS\AirshipAppExtensions.framework">
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
     </NativeReference>

--- a/src/AirshipExtensionBindings.iOS/AirshipExtensionBindings.iOS/AirshipExtensionBindings.iOS.csproj
+++ b/src/AirshipExtensionBindings.iOS/AirshipExtensionBindings.iOS/AirshipExtensionBindings.iOS.csproj
@@ -40,10 +40,10 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ObjcBindingApiDefinition Include="ApiDefinition.cs" />
+    <ObjcBindingApiDefinition Include="AirshipExtensionsApiDefinition.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ObjcBindingCoreSource Include="Structs.cs" />
+    <ObjcBindingCoreSource Include="AirshipExtensionsStructs.cs" />
   </ItemGroup>
   <ItemGroup>
     <NativeReference Include="..\..\..\Carthage\Build\iOS\AirshipAppExtensions.framework">

--- a/src/AirshipExtensionBindings.iOS/AirshipExtensionBindings.iOS/AirshipExtensionsApiDefinition.cs
+++ b/src/AirshipExtensionBindings.iOS/AirshipExtensionBindings.iOS/AirshipExtensionsApiDefinition.cs
@@ -1,4 +1,8 @@
-﻿using Foundation;
+﻿/*
+ Copyright 2016 Urban Airship and Contributors
+*/
+
+using Foundation;
 using UserNotifications;
 
 namespace AirshipAppExtensions

--- a/src/AirshipExtensionBindings.iOS/AirshipExtensionBindings.iOS/AirshipExtensionsStructs.cs
+++ b/src/AirshipExtensionBindings.iOS/AirshipExtensionBindings.iOS/AirshipExtensionsStructs.cs
@@ -1,0 +1,9 @@
+﻿/*
+ Copyright 2016 Urban Airship and Contributors
+*/
+
+using System;
+
+namespace AirshipAppExtensions
+{
+}

--- a/src/AirshipExtensionBindings.iOS/AirshipExtensionBindings.iOS/Structs.cs
+++ b/src/AirshipExtensionBindings.iOS/AirshipExtensionBindings.iOS/Structs.cs
@@ -1,5 +1,0 @@
-﻿using System;
-
-namespace AirshipAppExtensions
-{
-}

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("3.0.0")]
+[assembly: AssemblyVersion ("3.1.0")]
 

--- a/update_version.sh
+++ b/update_version.sh
@@ -4,6 +4,7 @@ VERSION=$1
 
 # Nuspec
 sed -i '' "s/<version>.*<\/version>/<version>$VERSION<\/version>/g" $ROOT_DIR/UrbanAirship.nuspec
+sed -i '' "s/<version>.*<\/version>/<version>$VERSION<\/version>/g" $ROOT_DIR/AirshipAppExtensions.nuspec
 
 # Xamarin component yaml
 sed -i '' "s/version: \".*\"/version: \"$VERSION\"/g" $ROOT_DIR/component/component.yaml


### PR DESCRIPTION
Fixes the extension for reals this time. 

The main airship bindings needs to contain the AirshipExtensions framework so its actually available in the app bundle. Extensions dependencies are ignored (Xamarin limitation). However we cant have the extension reference the main framework, for whatever reasons that fails. So we have the main package that includes both frameworks and an extension only framework for the extension. Yay. 