### PR TITLE
Resolve Issue with urbanairship.portable install into PCL

### DIFF
--- a/UrbanAirship.Portable.nuspec
+++ b/UrbanAirship.Portable.nuspec
@@ -9,7 +9,13 @@
       <description>A portable client library for the Urban Airship SDK.</description>
 
       <dependencies>
-          <dependency id="urbanairship" version="4.1.0"/>
+          <group targetFramework="MonoAndroid">
+            <dependency id="urbanairship" version="4.1.0"/>
+		  </group>
+		  
+		  <group targetFramework="Xamarin.iOS">
+		    <dependency id="urbanairship" version="4.1.0"/>
+		  </group>
       </dependencies>
    </metadata>
 


### PR DESCRIPTION
Currently when attempting to install the urbanairship.portable package into a PCL in a Xamarin Forms project the install will fail because it depends on urbanairship which has no assembly to match that profile.

Updated the nuspec file so only platform specific version of urbanairship.portable have that dependency.