### PR TITLE
Release 4.6.1

### DIFF
--- a/AirshipAppExtensions.nuspec
+++ b/AirshipAppExtensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.appextensions</id>
-      <version>4.6.0</version>
+      <version>4.6.1</version>
       <title>Urban Airship App Extensions</title>
       <authors>Urban Airship, Inc.</authors>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This component provides official bindings to the Urban Airship SDK, as well as s
 
 ### Release Notes
 
+Version 4.6.1 - October 2, 2017
+=============================
+- Deep link action had a run-time exception caused by ActionBlock having an incorrect binding.
+- Sample Push Handler was not validating a pointer, causing an NPE
+
 Version 4.6.0 - August 15, 2017
 =============================
 - Update Android Urban Airship SDK to 8.8.2.

--- a/UrbanAirship.Portable.nuspec
+++ b/UrbanAirship.Portable.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.portable</id>
-      <version>4.6.0</version>
+      <version>4.6.1</version>
       <title>Urban Airship SDK PCL</title>
       <authors>Urban Airship, Inc.</authors>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -10,11 +10,11 @@
 
       <dependencies>
           <group targetFramework="MonoAndroid">
-            <dependency id="urbanairship" version="4.6.0"/>
+            <dependency id="urbanairship" version="4.6.1"/>
 	  </group>
 
 	  <group targetFramework="Xamarin.iOS">
-	    <dependency id="urbanairship" version="4.6.0"/>
+	    <dependency id="urbanairship" version="4.6.1"/>
 	  </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.nuspec
+++ b/UrbanAirship.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship</id>
-      <version>4.6.0</version>
+      <version>4.6.1</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/airship.properties
+++ b/airship.properties
@@ -1,3 +1,3 @@
-libVersion = 4.6.0
+libVersion = 4.6.1
 iosVersion = 8.5.2
 androidVersion = 8.8.2

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ task syncVersion {
             file: "$projectDir/component/component.yaml",
             match: "urbanairship, Version=.*",
             replace: "urbanairship, Version=$airshipProperties.libVersion",
-	    flags: "g"
+            flags: "g"
         )
 
         // Shared assembly info

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,8 @@ task syncVersion {
         ant.replaceregexp(
             file: "$projectDir/component/component.yaml",
             match: "urbanairship, Version=.*",
-            replace: "urbanairship, Version=$airshipProperties.libVersion"
+            replace: "urbanairship, Version=$airshipProperties.libVersion",
+	    flags: "g"
         )
 
         // Shared assembly info

--- a/component/component.yaml
+++ b/component/component.yaml
@@ -14,15 +14,15 @@ libraries:
 summary: A full suite of mobile engagement tools for building next-generation apps
 details: ../CHANGELOG.md
 getting-started: GettingStarted.md
-version: "4.6.0"
+version: "4.6.1"
 samples:
   iOS Sample: ../samples/ios-unified/iOSSample.sln
   Android Sample: ../samples/android/AndroidSample.sln
 packages:
   android:
-    - urbanairship, Version=4.6.0
+    - urbanairship, Version=4.6.1
   ios-unified:
-    - urbanairship, Version=4.1.1
+    - urbanairship, Version=4.6.1
 is_shell: true
 no_build: true
 output: ../build

--- a/samples/ios-unified/PushHandler.cs
+++ b/samples/ios-unified/PushHandler.cs
@@ -83,9 +83,9 @@ namespace Sample
 			alertController.AddAction(okAction);
 
 			UIViewController topController = UIApplication.SharedApplication.KeyWindow.RootViewController;
-            if (alertController.PopoverPresentationController != null) {
-                alertController.PopoverPresentationController.SourceView = topController.View;
-            }
+			if (alertController.PopoverPresentationController != null) {
+				alertController.PopoverPresentationController.SourceView = topController.View;
+			}
 
 			topController.PresentViewController(alertController, true, null);
 

--- a/samples/ios-unified/PushHandler.cs
+++ b/samples/ios-unified/PushHandler.cs
@@ -83,7 +83,9 @@ namespace Sample
 			alertController.AddAction(okAction);
 
 			UIViewController topController = UIApplication.SharedApplication.KeyWindow.RootViewController;
-			alertController.PopoverPresentationController.SourceView = topController.View;
+            if (alertController.PopoverPresentationController != null) {
+                alertController.PopoverPresentationController.SourceView = topController.View;
+            }
 
 			topController.PresentViewController(alertController, true, null);
 

--- a/src/AirshipBindings.iOS/ApiDefinition.cs
+++ b/src/AirshipBindings.iOS/ApiDefinition.cs
@@ -3188,7 +3188,7 @@ namespace UrbanAirship {
 	delegate bool UAActionPredicate (UAActionArguments arg0);
 
 	// typedef void (^UAActionBlock)(UAActionArguments * _Nonnull, UAActionCompletionHandler _Nonnull);
-	delegate void UAActionBlock (UAActionArguments arg0, UAActionCompletionHandler arg1);
+	delegate void UAActionBlock(UAActionArguments arg0, [BlockCallback]UAActionCompletionHandler arg1);
 
 	// typedef void (^UAActionCompletionHandler)(UAActionResult * _Nonnull);
 	delegate void UAActionCompletionHandler (UAActionResult arg0);

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("4.6.0")]
+[assembly: AssemblyVersion ("4.6.1")]
 


### PR DESCRIPTION
Fix deep link action and sample push handler issues
- ActionBlock had incorrect binding, causing a run-time exception.
- Sample Push Handler was not validating a pointer, causing an NPE.

Fix build.gradle to update version that was being missed.

Manually tested on iOS 11.