### PR TITLE
Add UA notification service extension to sample app

### DIFF
--- a/samples/ios-unified/Info.plist
+++ b/samples/ios-unified/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>XamarinSample</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.urbanairship.xamarinsample</string>
+	<string>com.urbanairship.richpush</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/samples/ios-unified/Sample.csproj
+++ b/samples/ios-unified/Sample.csproj
@@ -172,6 +172,11 @@
       <Project>{58346B7E-E18F-4CB1-A9B8-C2266BDCFE2A}</Project>
       <Name>AirshipBindings.iOS</Name>
     </ProjectReference>
+    <ProjectReference Include="SampleServiceExtension\SampleServiceExtension.csproj">
+      <IsAppExtension>true</IsAppExtension>
+      <Project>{DDF8FDE3-49D5-4FF9-BF92-730A0C2F6E0A}</Project>
+      <Name>SampleServiceExtension</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('packages\Xamarin.Forms.2.3.4.247\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
 </Project>

--- a/samples/ios-unified/SampleServiceExtension/Entitlements.plist
+++ b/samples/ios-unified/SampleServiceExtension/Entitlements.plist
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/samples/ios-unified/SampleServiceExtension/Info.plist
+++ b/samples/ios-unified/SampleServiceExtension/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>SampleServiceExtension</string>
+	<key>CFBundleName</key>
+	<string>SampleServiceExtension</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.urbanairship.richpush.SampleServiceExtension</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>MinimumOSVersion</key>
+	<string>10.0</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>NotificationService</string>
+	</dict>
+</dict>
+</plist>

--- a/samples/ios-unified/SampleServiceExtension/NotificationService.cs
+++ b/samples/ios-unified/SampleServiceExtension/NotificationService.cs
@@ -1,0 +1,10 @@
+﻿using Foundation;
+using AirshipAppExtensions;
+
+namespace SampleServiceExtension
+{
+    [Register("NotificationService")]
+    public class NotificationService : UAMediaAttachmentExtension
+    {
+    }
+}

--- a/samples/ios-unified/SampleServiceExtension/SampleServiceExtension.csproj
+++ b/samples/ios-unified/SampleServiceExtension/SampleServiceExtension.csproj
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{DDF8FDE3-49D5-4FF9-BF92-730A0C2F6E0A}</ProjectGuid>
+    <ProjectTypeGuids>{EE2C853D-36AF-4FDB-B1AD-8E90477E2198};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>SampleServiceExtension</RootNamespace>
+    <AssemblyName>SampleServiceExtension</AssemblyName>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchFastDev>true</MtouchFastDev>
+    <IOSDebuggerPort>37393</IOSDebuggerPort>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <DeviceSpecificBuild>false</DeviceSpecificBuild>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <DefineConstants></DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARM64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <DefineConstants></DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>x86_64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <DeviceSpecificBuild>true</DeviceSpecificBuild>
+    <MtouchDebug>true</MtouchDebug>
+    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <IOSDebuggerPort>17833</IOSDebuggerPort>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARM64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+    <Reference Include="AirshipExtensionBindings.iOS">
+      <HintPath>..\packages\urbanairship.appextensions.4.6.1\lib\Xamarin.iOS10\AirshipExtensionBindings.iOS.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="NotificationService.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />
+</Project>

--- a/samples/ios-unified/SampleServiceExtension/packages.config
+++ b/samples/ios-unified/SampleServiceExtension/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="urbanairship.appextensions" version="4.6.1" targetFramework="xamarinios10" />
+</packages>

--- a/samples/ios-unified/iOSSample.sln
+++ b/samples/ios-unified/iOSSample.sln
@@ -5,6 +5,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample", "Sample.csproj", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirshipBindings.iOS", "..\..\src\AirshipBindings.iOS\AirshipBindings.iOS.csproj", "{58346B7E-E18F-4CB1-A9B8-C2266BDCFE2A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleServiceExtension", "SampleServiceExtension\SampleServiceExtension.csproj", "{DDF8FDE3-49D5-4FF9-BF92-730A0C2F6E0A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|iPhoneSimulator = Debug|iPhoneSimulator
@@ -29,5 +31,13 @@ Global
 		{C6EB4686-06A0-4B33-AEDE-C42E5EC8CA50}.Release|iPhone.Build.0 = Release|iPhone
 		{C6EB4686-06A0-4B33-AEDE-C42E5EC8CA50}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
 		{C6EB4686-06A0-4B33-AEDE-C42E5EC8CA50}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{DDF8FDE3-49D5-4FF9-BF92-730A0C2F6E0A}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{DDF8FDE3-49D5-4FF9-BF92-730A0C2F6E0A}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{DDF8FDE3-49D5-4FF9-BF92-730A0C2F6E0A}.Release|iPhone.ActiveCfg = Release|iPhone
+		{DDF8FDE3-49D5-4FF9-BF92-730A0C2F6E0A}.Release|iPhone.Build.0 = Release|iPhone
+		{DDF8FDE3-49D5-4FF9-BF92-730A0C2F6E0A}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{DDF8FDE3-49D5-4FF9-BF92-730A0C2F6E0A}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{DDF8FDE3-49D5-4FF9-BF92-730A0C2F6E0A}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{DDF8FDE3-49D5-4FF9-BF92-730A0C2F6E0A}.Debug|iPhone.Build.0 = Debug|iPhone
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Had to figure out to do this to answer a customer question about it. Might as well just put it in the repo. I also changed the bundle id to the same as our iOS samples, so I won't keep forgetting to change it when I'm testing.