### PR TITLE
Enable use of IUAInboxDelegate protocol

### DIFF
--- a/AirshipAppExtensions.nuspec
+++ b/AirshipAppExtensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.appextensions</id>
-      <version>4.6.1</version>
+      <version>4.6.2</version>
       <title>Urban Airship App Extensions</title>
       <authors>Urban Airship, Inc.</authors>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This component provides official bindings to the Urban Airship SDK, as well as s
 
 ### Release Notes
 
+Version 4.6.2 - December 5, 2017
+=============================
+- Enable use of IUAInboxDelegate protocol.
+
 Version 4.6.1 - October 2, 2017
 =============================
 - Deep link action had a run-time exception caused by ActionBlock having an incorrect binding.

--- a/UrbanAirship.Portable.nuspec
+++ b/UrbanAirship.Portable.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.portable</id>
-      <version>4.6.1</version>
+      <version>4.6.2</version>
       <title>Urban Airship SDK PCL</title>
       <authors>Urban Airship, Inc.</authors>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -10,11 +10,11 @@
 
       <dependencies>
           <group targetFramework="MonoAndroid">
-            <dependency id="urbanairship" version="4.6.1"/>
+            <dependency id="urbanairship" version="4.6.2"/>
 	  </group>
 
 	  <group targetFramework="Xamarin.iOS">
-	    <dependency id="urbanairship" version="4.6.1"/>
+	    <dependency id="urbanairship" version="4.6.2"/>
 	  </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.nuspec
+++ b/UrbanAirship.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship</id>
-      <version>4.6.1</version>
+      <version>4.6.2</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/airship.properties
+++ b/airship.properties
@@ -1,3 +1,3 @@
-libVersion = 4.6.1
+libVersion = 4.6.2
 iosVersion = 8.5.2
 androidVersion = 8.8.2

--- a/component/component.yaml
+++ b/component/component.yaml
@@ -14,15 +14,15 @@ libraries:
 summary: A full suite of mobile engagement tools for building next-generation apps
 details: ../CHANGELOG.md
 getting-started: GettingStarted.md
-version: "4.6.1"
+version: "4.6.2"
 samples:
   iOS Sample: ../samples/ios-unified/iOSSample.sln
   Android Sample: ../samples/android/AndroidSample.sln
 packages:
   android:
-    - urbanairship, Version=4.6.1
+    - urbanairship, Version=4.6.2
   ios-unified:
-    - urbanairship, Version=4.6.1
+    - urbanairship, Version=4.6.2
 is_shell: true
 no_build: true
 output: ../build

--- a/src/AirshipBindings.iOS/ApiDefinition.cs
+++ b/src/AirshipBindings.iOS/ApiDefinition.cs
@@ -1604,11 +1604,11 @@ namespace UrbanAirship {
 
 		// @property (nonatomic, weak) id<UAInboxDelegate> _Nullable delegate;
 		[NullAllowed, Export ("delegate", ArgumentSemantic.Assign)]
-		NSObject WeakDelegate { get; set; }
+        IUAInboxDelegate WeakDelegate { get; set; }
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]
-		UAInboxDelegate Delegate { get; set; }
+        IUAInboxDelegate Delegate { get; set; }
 	}
 
 	// @interface UAInboxMessage : NSObject
@@ -3057,6 +3057,8 @@ namespace UrbanAirship {
 		[Export ("showInbox")]
 		void ShowInbox ();
 	}
+
+    interface IUAInboxDelegate { }
 
 	// @protocol UAJavaScriptDelegate <NSObject>
 	[Protocol, Model]

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("4.6.1")]
+[assembly: AssemblyVersion ("4.6.2")]
 


### PR DESCRIPTION
Changes the type of UAInbox delegates to the "IUAInboxDelegate" protocol, so classes that implement that protocol can be UAInboxDelegates. Doesn't require any source changes.