### PR TITLE
Release 4.6.4

### DIFF
--- a/AirshipAppExtensions.nuspec
+++ b/AirshipAppExtensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.appextensions</id>
-      <version>4.6.3</version>
+      <version>4.6.4</version>
       <title>Urban Airship App Extensions</title>
       <authors>Urban Airship, Inc.</authors>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ This component provides official bindings to the Urban Airship SDK, as well as s
 
 ### Release Notes
 
-Version 4.6.2 - December 12, 2017
+Version 4.6.4 - January 12, 2018
+=============================
+- Enable use of UAMessageCenterMessageViewController class.
+- Enable use of initWithNibName:bundle: method in UAMessageCenterMessageViewController and UADefaultMessageCenterMessageViewController classes.
+
+Version 4.6.3 - December 12, 2017
 =============================
 - Enable use of IUAInAppMessageControllerDelegate protocol.
 

--- a/UrbanAirship.Portable.nuspec
+++ b/UrbanAirship.Portable.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship.portable</id>
-      <version>4.6.3</version>
+      <version>4.6.4</version>
       <title>Urban Airship SDK PCL</title>
       <authors>Urban Airship, Inc.</authors>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -10,11 +10,11 @@
 
       <dependencies>
           <group targetFramework="MonoAndroid">
-            <dependency id="urbanairship" version="4.6.3"/>
+            <dependency id="urbanairship" version="4.6.4"/>
 	  </group>
 
 	  <group targetFramework="Xamarin.iOS">
-	    <dependency id="urbanairship" version="4.6.3"/>
+	    <dependency id="urbanairship" version="4.6.4"/>
 	  </group>
       </dependencies>
    </metadata>

--- a/UrbanAirship.nuspec
+++ b/UrbanAirship.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata>
       <id>urbanairship</id>
-      <version>4.6.3</version>
+      <version>4.6.4</version>
       <title>Urban Airship SDK</title>
       <authors>Urban Airship, Inc.</authors>
       <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/airship.properties
+++ b/airship.properties
@@ -1,3 +1,3 @@
-libVersion = 4.6.3
+libVersion = 4.6.4
 iosVersion = 8.5.2
 androidVersion = 8.8.2

--- a/component/component.yaml
+++ b/component/component.yaml
@@ -14,15 +14,15 @@ libraries:
 summary: A full suite of mobile engagement tools for building next-generation apps
 details: ../CHANGELOG.md
 getting-started: GettingStarted.md
-version: "4.6.3"
+version: "4.6.4"
 samples:
   iOS Sample: ../samples/ios-unified/iOSSample.sln
   Android Sample: ../samples/android/AndroidSample.sln
 packages:
   android:
-    - urbanairship, Version=4.6.3
+    - urbanairship, Version=4.6.4
   ios-unified:
-    - urbanairship, Version=4.6.3
+    - urbanairship, Version=4.6.4
 is_shell: true
 no_build: true
 output: ../build

--- a/src/AirshipBindings.iOS/ApiDefinition.cs
+++ b/src/AirshipBindings.iOS/ApiDefinition.cs
@@ -1229,7 +1229,12 @@ namespace UrbanAirship {
 	[BaseType (typeof(UIViewController))]
 	interface UADefaultMessageCenterMessageViewController : IUIWebViewDelegate, UARichContentWindow
 	{
-		// -(void)loadMessageAtIndex:(NSUInteger)index;
+        // -(instancetype _Nonnull)initWithNibName:(NSString * _Nullable)nibNameOrNil bundle:(NSBundle * _Nullable)nibBundleOrNil __attribute__((objc_designated_initializer));
+        [Export("initWithNibName:bundle:")]
+        [DesignatedInitializer]
+        IntPtr Constructor([NullAllowed] string nibNameOrNil, [NullAllowed] NSBundle nibBundleOrNil);
+
+        // -(void)loadMessageAtIndex:(NSUInteger)index;
 		[Export ("loadMessageAtIndex:")]
 		void LoadMessageAtIndex (nuint index);
 
@@ -2151,7 +2156,7 @@ namespace UrbanAirship {
 		UIUserNotificationCategory AsUIUserNotificationCategory { get; }
 
 		// -(UNNotificationCategory * _Null_unspecified)asUNNotificationCategory __attribute__((availability(ios, introduced=10.0)));
-		[iOS (10, 0)]
+        [Introduced(PlatformName.iOS, 10, 0, message: "Introduced in iOS 10")]
 		[Export ("asUNNotificationCategory")]
 		UNNotificationCategory AsUNNotificationCategory { get; }
 
@@ -3091,6 +3096,16 @@ namespace UrbanAirship {
 		void ReceivedLocationUpdates(NSObject[] locations);
 	}
 
+    // @interface UAMessageCenterMessageViewController : UIViewController <UAWKWebViewDelegate, UAMessageCenterMessageViewProtocol>
+    [BaseType(typeof(UIViewController))]
+    interface UAMessageCenterMessageViewController : IUAWKWebViewDelegate, UAMessageCenterMessageViewProtocol
+    {
+        // -(instancetype _Nonnull)initWithNibName:(NSString * _Nullable)nibNameOrNil bundle:(NSBundle * _Nullable)nibBundleOrNil __attribute__((objc_designated_initializer));
+        [Export("initWithNibName:bundle:")]
+        [DesignatedInitializer]
+        IntPtr Constructor([NullAllowed] string nibNameOrNil, [NullAllowed] NSBundle nibBundleOrNil);
+    }
+
 	// @protocol UAMessageCenterMessageViewProtocol
 	[Protocol, Model]
 	interface UAMessageCenterMessageViewProtocol
@@ -3187,6 +3202,8 @@ namespace UrbanAirship {
 		[Export ("closeWindowAnimated:")]
 		void CloseWindowAnimated(bool animated);
 	}
+
+    interface IUAWKWebViewDelegate { }
 
 	// typedef BOOL (^UAActionPredicate)(UAActionArguments * _Nonnull);
 	delegate bool UAActionPredicate (UAActionArguments arg0);

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion ("4.6.3")]
+[assembly: AssemblyVersion ("4.6.4")]
 


### PR DESCRIPTION
- Enable use of UAMessageCenterMessageViewController class.
- Enable use of initWithNibName:bundle: method in UAMessageCenterMessageViewController and UADefaultMessageCenterMessageViewController classes.