### PR TITLE
[MOBILE-178] Some dependency cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,5 @@ local-nuget-feed/
 
 # UA native jars
 urbanairship*.aar
+
+google-services.json

--- a/UrbanAirship.Android.FCM.nuspec
+++ b/UrbanAirship.Android.FCM.nuspec
@@ -11,6 +11,7 @@
       <dependencies>
          <group targetFramework="MonoAndroid">
             <dependency id="Xamarin.Firebase.Messaging" version="60.1142.1" />
+            <dependency id="Xamarin.GooglePlayServices.Base" version="60.1142.1" />
             <dependency id="urbanairship.android.core" version="9.2.0"/>
          </group>
       </dependencies>

--- a/build.gradle
+++ b/build.gradle
@@ -22,33 +22,6 @@ task generateDeps {
                 i -> nugetExe.withOutputStream{ it << i }
             }
         }
-
-        // Download xamarin component if it doesn't exist.
-        if (!xamarinComponentExe.exists()) {
-            def temp = new File("$toolsDir/xpkg")
-            new URL('https://components.xamarin.com/submit/xpkg').withInputStream{
-                i -> temp.withOutputStream{ it << i }
-            }
-            copy {
-                from zipTree(temp)
-                into "$toolsDir"
-            }
-            delete temp
-        }
-    }
-}
-
-task buildComponent {
-    doLast() {
-        exec {
-            commandLine "mono", "${xamarinComponentExe}", "package", "$componentDir", "-OutputDirectory", "$buildDir"
-        }
-
-        copy {
-            from "$componentDir"
-            include "*.xam"
-            into "$buildDir"
-        }
     }
 }
 
@@ -79,11 +52,15 @@ task pkg {
         }
     }
 }
-pkg.mustRunAfter('build')
+pkg.dependsOn('build')
 
 // Create local nuget feed
 task createLocalFeed {
     doLast() {
+        // add doesn't have a "-force" option, so first remove all the nuget packages from the local feed
+        File localNugetFeed = file("${rootDir}/local-nuget-feed")
+        localNugetFeed.deleteDir()
+
         // get all the nuget packages from the build directory
         def nupkgs = buildDir.listFiles(new FilenameFilter() {
             public boolean accept(File dir, String name) {
@@ -92,12 +69,7 @@ task createLocalFeed {
         }) 
 
         // add the packages to the local nuget feed
-        File localNugetFeed = file("${rootDir}/local-nuget-feed")
         nupkgs.each { nupkg ->
-            // add doesn't have a "-force" option, so first remove the nuget package from the local feed
-            exec {
-                commandLine "mono", "${nugetExe}", "delete", "$nupkg", "-source", "$localNugetFeed", "-noprompt"
-            }
             // add the package to the local nuget feed
             exec {
                 commandLine "mono", "${nugetExe}", "add", "$nupkg", "-source", "$localNugetFeed" 
@@ -111,7 +83,6 @@ task createLocalFeed {
         
     }
 }
-createLocalFeed.dependsOn('build')
 createLocalFeed.dependsOn('pkg')
 
 // Sync the version with the version declared in the airship.properties file.
@@ -213,4 +184,3 @@ build.dependsOn(':docs:build',
     ':src:AirshipBindings.Portable:build',
     ':src:AirshipBindings.iOS:build',
     ':src:AirshipBindings.iOS.AppExtensions:build')
-build.finalizedBy('buildComponent')

--- a/samples/android/packages.config
+++ b/samples/android/packages.config
@@ -18,9 +18,4 @@
   <package id="Xamarin.Android.Support.v7.RecyclerView" version="27.0.2" targetFramework="monoandroid81" />
   <package id="Xamarin.Android.Support.Vector.Drawable" version="27.0.2" targetFramework="monoandroid81" />
   <package id="Xamarin.Build.Download" version="0.4.9" targetFramework="monoandroid81" />
-  <package id="Xamarin.GooglePlayServices.Base" version="60.1142.1" targetFramework="monoandroid81" />
-  <package id="Xamarin.GooglePlayServices.Basement" version="60.1142.1" targetFramework="monoandroid81" />
-  <package id="Xamarin.GooglePlayServices.Gcm" version="60.1142.1" targetFramework="monoandroid81" />
-  <package id="Xamarin.GooglePlayServices.Iid" version="60.1142.1" targetFramework="monoandroid81" />
-  <package id="Xamarin.GooglePlayServices.Tasks" version="60.1142.1" targetFramework="monoandroid81" />
 </packages>

--- a/src/AirshipBindings.Android.Core/AirshipBindings.Android.Core.csproj
+++ b/src/AirshipBindings.Android.Core/AirshipBindings.Android.Core.csproj
@@ -72,18 +72,6 @@
     <Reference Include="Xamarin.Android.Support.v4">
       <HintPath>packages\Xamarin.Android.Support.v4.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Basement">
-      <HintPath>packages\Xamarin.GooglePlayServices.Basement.60.1142.1\lib\MonoAndroid80\Xamarin.GooglePlayServices.Basement.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Tasks">
-      <HintPath>packages\Xamarin.GooglePlayServices.Tasks.60.1142.1\lib\MonoAndroid80\Xamarin.GooglePlayServices.Tasks.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Base">
-      <HintPath>packages\Xamarin.GooglePlayServices.Base.60.1142.1\lib\MonoAndroid80\Xamarin.GooglePlayServices.Base.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Iid">
-      <HintPath>packages\Xamarin.GooglePlayServices.Iid.60.1142.1\lib\MonoAndroid80\Xamarin.GooglePlayServices.Iid.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.Android.Support.Vector.Drawable">
       <HintPath>..\AirshipBindings.NETStandard\packages\Xamarin.Android.Support.Vector.Drawable.27.0.2\lib\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
     </Reference>
@@ -161,10 +149,6 @@
   <Import Project="packages\Xamarin.Android.Support.Media.Compat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Media.Compat.targets" Condition="Exists('packages\Xamarin.Android.Support.Media.Compat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Media.Compat.targets')" />
   <Import Project="packages\Xamarin.Android.Support.v4.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v4.targets" Condition="Exists('packages\Xamarin.Android.Support.v4.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v4.targets')" />
   <Import Project="packages\Xamarin.Build.Download.0.4.9\build\Xamarin.Build.Download.targets" Condition="Exists('packages\Xamarin.Build.Download.0.4.9\build\Xamarin.Build.Download.targets')" />
-  <Import Project="packages\Xamarin.GooglePlayServices.Basement.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Basement.targets" Condition="Exists('packages\Xamarin.GooglePlayServices.Basement.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Basement.targets')" />
-  <Import Project="packages\Xamarin.GooglePlayServices.Tasks.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Tasks.targets" Condition="Exists('packages\Xamarin.GooglePlayServices.Tasks.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Tasks.targets')" />
-  <Import Project="packages\Xamarin.GooglePlayServices.Base.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Base.targets" Condition="Exists('packages\Xamarin.GooglePlayServices.Base.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Base.targets')" />
-  <Import Project="packages\Xamarin.GooglePlayServices.Iid.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Iid.targets" Condition="Exists('packages\Xamarin.GooglePlayServices.Iid.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Iid.targets')" />
   <Import Project="..\AirshipBindings.NETStandard\packages\Xamarin.Android.Support.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\AirshipBindings.NETStandard\packages\Xamarin.Android.Support.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Vector.Drawable.targets')" />
   <Import Project="..\AirshipBindings.NETStandard\packages\Xamarin.Android.Support.Animated.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Animated.Vector.Drawable.targets" Condition="Exists('..\AirshipBindings.NETStandard\packages\Xamarin.Android.Support.Animated.Vector.Drawable.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.Animated.Vector.Drawable.targets')" />
   <Import Project="..\AirshipBindings.NETStandard\packages\Xamarin.Android.Support.v7.AppCompat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.AppCompat.targets" Condition="Exists('..\AirshipBindings.NETStandard\packages\Xamarin.Android.Support.v7.AppCompat.27.0.2\build\MonoAndroid81\Xamarin.Android.Support.v7.AppCompat.targets')" />

--- a/src/AirshipBindings.Android.Core/packages.config
+++ b/src/AirshipBindings.Android.Core/packages.config
@@ -14,8 +14,4 @@
   <package id="Xamarin.Android.Support.v7.AppCompat" version="27.0.2" targetFramework="monoandroid81" />
   <package id="Xamarin.Android.Support.Vector.Drawable" version="27.0.2" targetFramework="monoandroid81" />
   <package id="Xamarin.Build.Download" version="0.4.9" targetFramework="monoandroid81" />
-  <package id="Xamarin.GooglePlayServices.Base" version="60.1142.1" targetFramework="monoandroid81" />
-  <package id="Xamarin.GooglePlayServices.Basement" version="60.1142.1" targetFramework="monoandroid81" />
-  <package id="Xamarin.GooglePlayServices.Iid" version="60.1142.1" targetFramework="monoandroid81" />
-  <package id="Xamarin.GooglePlayServices.Tasks" version="60.1142.1" targetFramework="monoandroid81" />
 </packages>

--- a/src/AirshipBindings.Android.FCM/AirshipBindings.Android.FCM.csproj
+++ b/src/AirshipBindings.Android.FCM/AirshipBindings.Android.FCM.csproj
@@ -86,6 +86,9 @@
     <Reference Include="Xamarin.Firebase.Messaging">
       <HintPath>..\..\samples\android\packages\Xamarin.Firebase.Messaging.60.1142.1\lib\MonoAndroid80\Xamarin.Firebase.Messaging.dll</HintPath>
     </Reference>
+    <Reference Include="Xamarin.GooglePlayServices.Base">
+      <HintPath>..\..\samples\android\packages\Xamarin.GooglePlayServices.Base.60.1142.1\lib\MonoAndroid80\Xamarin.GooglePlayServices.Base.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -132,4 +135,5 @@
   <Import Project="..\..\samples\android\packages\Xamarin.Firebase.Common.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Common.targets" Condition="Exists('..\..\samples\android\packages\Xamarin.Firebase.Common.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Common.targets')" />
   <Import Project="..\..\samples\android\packages\Xamarin.Firebase.Iid.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Iid.targets" Condition="Exists('..\..\samples\android\packages\Xamarin.Firebase.Iid.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Iid.targets')" />
   <Import Project="..\..\samples\android\packages\Xamarin.Firebase.Messaging.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Messaging.targets" Condition="Exists('..\..\samples\android\packages\Xamarin.Firebase.Messaging.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Messaging.targets')" />
+  <Import Project="..\..\samples\android\packages\Xamarin.GooglePlayServices.Base.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Base.targets" Condition="Exists('..\..\samples\android\packages\Xamarin.GooglePlayServices.Base.60.1142.1\build\MonoAndroid80\Xamarin.GooglePlayServices.Base.targets')" />
 </Project>

--- a/src/AirshipBindings.Android.FCM/packages.config
+++ b/src/AirshipBindings.Android.FCM/packages.config
@@ -13,6 +13,7 @@
   <package id="Xamarin.Firebase.Common" version="60.1142.1" targetFramework="monoandroid81" />
   <package id="Xamarin.Firebase.Iid" version="60.1142.1" targetFramework="monoandroid81" />
   <package id="Xamarin.Firebase.Messaging" version="60.1142.1" targetFramework="monoandroid81" />
+  <package id="Xamarin.GooglePlayServices.Base" version="60.1142.1" targetFramework="monoandroid81" />
   <package id="Xamarin.GooglePlayServices.Basement" version="60.1142.1" targetFramework="monoandroid81" />
   <package id="Xamarin.GooglePlayServices.Tasks" version="60.1142.1" targetFramework="monoandroid81" />
 </packages>


### PR DESCRIPTION
- Add `Xamarin.GooglePlayServices.Base` as a dependency of the `UrbanAirship.Android.FCM` package, so it doesn't need to be manually added to Xamarin apps. `Xamarin.GooglePlayServices.Base` is already in UrbanAirship.Android.FCM` as a dependency of `Xamarin.GooglePlayServices.Gcm`
- Fix deletion of local nuget feed
- Remove xamarin component build (The Component Store has been discontinued as of May 15, 2018.)

Tested on sample app with FCM and GCM.